### PR TITLE
bump version in codeql-go github action

### DIFF
--- a/codeql-go/action.yml
+++ b/codeql-go/action.yml
@@ -11,14 +11,14 @@ runs:
         go-version-file: go.mod
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: "go"
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:go"


### PR DESCRIPTION
After this update, I want to see if this github action is more reliable for our CI than the baked in CodeQL check that Github provides. The baked in check is not on the latest version and it's not clear where it derives its go version