### PR TITLE
Create grype.yml

### DIFF
--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -1,0 +1,32 @@
+name: Security - Grype Scan Repo
+
+on:
+  workflow_call:
+    inputs:
+      alias:
+        type: string
+        required: true
+    secrets:
+      ORG_GITHUB_TOKEN:
+        required: true
+      GRYPE_INTEGRATION_SECRET:
+        required: true
+
+jobs:
+  scan-repo-for-vulns:
+    runs-on: ubuntu-latest
+    container:
+      image: public.ecr.aws/opslevel/platform-tools:latest
+      env:
+        ORG_GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+        GRYPE_INTEGRATION_SECRET: ${{ secrets.GRYPE_INTEGRATION_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
+      - name: Scan
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+          grype dir:$(pwd) --only-fixed -o json | jq '{"matches": .matches}' |
+          curl -s -X POST https://upload.opslevel.com/integrations/custom_event/${GRYPE_INTEGRATION_SECRET}?alias=${{ inputs.alias }} -H 'content-type: application/json'  --data-binary @-


### PR DESCRIPTION
So because i'm going to have to add this to 10 repos i want to try out a reusable workflow now that github supports secrets being inherited - https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow

In the upstream repo that will call this it should look something like

```yaml
name: Security

on:
  workflow_dispatch: {}
  schedule:
    - cron: "0 13 * * 1"  # 8am CT on Mondays

jobs:
  call-grype:
    uses: opslevel/actions/.github/workflows/grype.yml@main
    with:
      alias: opslevel-runner
    secrets: inherit
```